### PR TITLE
oninit action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /dist
 /fastboot-dist
 /tmp
+/test-output
 
 # dependencies
 /node_modules

--- a/addon/components/power-select-multiple.js
+++ b/addon/components/power-select-multiple.js
@@ -3,7 +3,6 @@ import Component from 'ember-component';
 import computed from 'ember-computed';
 import layout from '../templates/components/power-select-multiple';
 import fallbackIfUndefined from '../utils/computed-fallback-if-undefined';
-import { scheduleOnce } from 'ember-runloop';
 
 const { isEqual } = Ember;
 
@@ -42,18 +41,12 @@ export default Component.extend({
     }
   }),
 
-  // Lifecycle hooks
-  init() {
-    this._super(...arguments);
-    scheduleOnce('afterRender', this, this.send, 'handleInit');
-  },
-
   // Actions
   actions: {
-    handleInit() {
+    handleInit(select) {
       let action = this.get('oninit');
       if (action) {
-        action(this.get('publicAPI'));
+        action(select);
       }
     },
 

--- a/addon/components/power-select-multiple.js
+++ b/addon/components/power-select-multiple.js
@@ -3,6 +3,7 @@ import Component from 'ember-component';
 import computed from 'ember-computed';
 import layout from '../templates/components/power-select-multiple';
 import fallbackIfUndefined from '../utils/computed-fallback-if-undefined';
+import { scheduleOnce } from 'ember-runloop';
 
 const { isEqual } = Ember;
 
@@ -41,8 +42,21 @@ export default Component.extend({
     }
   }),
 
+  // Lifecycle hooks
+  init() {
+    this._super(...arguments);
+    scheduleOnce('afterRender', this, this.send, 'handleInit');
+  },
+
   // Actions
   actions: {
+    handleInit() {
+      let action = this.get('oninit');
+      if (action) {
+        action(this.get('publicAPI'));
+      }
+    },
+
     handleOpen(select, e) {
       let action = this.get('onopen');
       if (action && action(select, e) === false) {

--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -108,6 +108,7 @@ export default Component.extend({
       scrollTo: (...args) => scheduleOnce('afterRender', this, this.send, 'scrollTo', ...args)
     };
     assert('{{power-select}} requires an `onchange` function', this.get('onchange') && typeof this.get('onchange') === 'function');
+    scheduleOnce('afterRender', this, this.send, 'onInit');
   },
 
   willDestroy() {
@@ -206,6 +207,13 @@ export default Component.extend({
       let action = this.get('registerAPI');
       if (action) {
         action(publicAPI);
+      }
+    },
+
+    onInit() {
+      let action = this.get('oninit');
+      if (action) {
+        action(this.get('publicAPI'));
       }
     },
 

--- a/addon/templates/components/power-select-multiple.hbs
+++ b/addon/templates/components/power-select-multiple.hbs
@@ -27,6 +27,7 @@
     onchange=onchange
     onclose=onclose
     onfocus=(action "handleFocus")
+    oninit=(action "handleInit")
     oninput=oninput
     onkeydown=(action "handleKeydown")
     onopen=(action "handleOpen")
@@ -85,6 +86,7 @@
     onchange=onchange
     onclose=onclose
     onfocus=(action "handleFocus")
+    oninit=(action "handleInit")
     oninput=oninput
     onkeydown=(action "handleKeydown")
     onopen=(action "handleOpen")

--- a/tests/integration/components/power-select/public-actions-test.js
+++ b/tests/integration/components/power-select/public-actions-test.js
@@ -397,6 +397,21 @@ test('returning false from the `onopen` action prevents the multiple select from
   assert.notOk(find('.ember-power-select-dropdown'), 'Dropdown didn\'t open');
 });
 
+test('the `oninit` action is invoked when the component is rendered', function(assert) {
+  assert.expect(21);
+
+  this.numbers = numbers;
+  this.handleInit = (select) => {
+    assertPublicAPIShape(assert, select);
+  };
+
+  this.render(hbs`
+    {{#power-select options=numbers onchange=(action (mut foo)) oninit=handleInit as |option|}}
+      {{option}}
+    {{/power-select}}
+  `);
+});
+
 test('the `onclose` action is invoked just before the dropdown closes', function(assert) {
   assert.expect(24);
 

--- a/tests/integration/components/power-select/public-actions-test.js
+++ b/tests/integration/components/power-select/public-actions-test.js
@@ -397,7 +397,7 @@ test('returning false from the `onopen` action prevents the multiple select from
   assert.notOk(find('.ember-power-select-dropdown'), 'Dropdown didn\'t open');
 });
 
-test('the `oninit` action is invoked when the component is rendered', function(assert) {
+test('the `oninit` action is invoked when the single select is rendered', function(assert) {
   assert.expect(21);
 
   this.numbers = numbers;
@@ -409,6 +409,21 @@ test('the `oninit` action is invoked when the component is rendered', function(a
     {{#power-select options=numbers onchange=(action (mut foo)) oninit=handleInit as |option|}}
       {{option}}
     {{/power-select}}
+  `);
+});
+
+test('the `oninit` action is invoked when the multiple select is rendered', function(assert) {
+  assert.expect(21);
+
+  this.numbers = numbers;
+  this.handleInit = (select) => {
+    assertPublicAPIShape(assert, select);
+  };
+
+  this.render(hbs`
+    {{#power-select-multiple options=numbers onchange=(action (mut foo)) oninit=handleInit as |option|}}
+      {{option}}
+    {{/power-select-multiple}}
   `);
 });
 


### PR DESCRIPTION
This PR introduces the `oninit` action for the `power-select` and `power-select-multiple` components, primarily to hook up to the [initalized action](https://github.com/salsify/ui-selectors/blob/master/addon/components/dynamic-selector/component.js#L119) in ui-selectors.

prime: @dfreeman 