### PR TITLE
Apply changes since fork

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 /connect.lock
 /coverage/*
 /libpeerconnection.log
+/test-output
 npm-debug.log*
 yarn-error.log
 testem.log

--- a/addon-test-support/helpers.js
+++ b/addon-test-support/helpers.js
@@ -1,7 +1,7 @@
 import { deprecate, warn } from '@ember/debug';
 import { registerAsyncHelper } from '@ember/test';
 import wait from 'ember-test-helpers/wait';
-import { click, fillIn, keyEvent, triggerEvent, find, findAll } from 'ember-native-dom-helpers';
+import { click, fillIn, keyEvent, triggerEvent, find, findAll, scrollTo } from 'ember-native-dom-helpers';
 
 /**
  * @private
@@ -24,6 +24,11 @@ export function nativeMouseUp(selectorOrDomElement, options) {
 
 export function triggerKeydown(domElement, k) {
   keyEvent(domElement, 'keydown', k);
+}
+
+export function triggerScroll(x = 0, y = 0) {
+  let selector = '.ember-power-select-options';
+  return scrollTo(selector, x, y);
 }
 
 export function typeInSearch(scopeOrText, text) {

--- a/addon/components/power-select.js
+++ b/addon/components/power-select.js
@@ -1,6 +1,6 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
-import { scheduleOnce } from '@ember/runloop';
+import { scheduleOnce, throttle } from '@ember/runloop';
 import { getOwner } from '@ember/application';
 import { isEqual } from '@ember/utils';
 import { get, set } from '@ember/object';
@@ -384,6 +384,13 @@ export default Component.extend({
       let action = this.get('onblur');
       if (action) {
         action(this.get('publicAPI'), event);
+      }
+    },
+
+    onScroll(event) {
+      let action = this.get('onscroll');
+      if (action) {
+        throttle(null, action, this.get('publicAPI'), event, 100, false);
       }
     },
 

--- a/addon/components/power-select/options.js
+++ b/addon/components/power-select/options.js
@@ -25,7 +25,7 @@ export default Component.extend({
   isTouchDevice: (!!self.window && 'ontouchstart' in self.window),
   layout,
   tagName: 'ul',
-  attributeBindings: ['role', 'aria-controls'],
+  attributeBindings: ['role', 'aria-controls', 'onScroll:onscroll'],
   role: 'listbox',
 
   // Lifecycle hooks

--- a/addon/templates/components/power-select.hbs
+++ b/addon/templates/components/power-select.hbs
@@ -87,6 +87,7 @@
         id=(readonly optionsId)
         options=(readonly publicAPI.results)
         optionsComponent=(readonly optionsComponent)
+        onScroll=(action "onScroll")
         groupComponent=(readonly groupComponent)
         select=(readonly publicAPI)
         as |option term|}}

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,22 @@
+machine:
+  node:
+    version: 6
+
+dependencies:
+  pre:
+    # Install Yarn
+    - sudo apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg
+    - echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+    - sudo apt-get update -qq
+    - sudo apt-get install -y -qq yarn=0.18.1-1
+
+    - yarn global add bower phantomjs-prebuilt
+    - curl -u ${ARTIFACTORY_CREDENTIALS} https://npm.salsify.com/api/npm/npm-local/auth/salsify >> ~/.npmrc
+  override:
+    - yarn install
+  cache_directories:
+    - ~/.cache/yarn
+
+test:
+  post:
+    - cp -R test-output/* ${CIRCLE_TEST_REPORTS}

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -4,20 +4,6 @@ module.exports = {
   command: 'ember test --reporter xunit --skip-cleanup=true',
   scenarios: [
     {
-      name: 'ember-2.10',
-      bower: {
-        dependencies: {
-          ember: '~2.10.0'
-        }
-      },
-      npm: {
-        devDependencies: {
-          'ember-source': null,
-          'ember-native-dom-event-dispatcher': null
-        }
-      }
-    },
-    {
       name: 'ember-lts-2.12',
       npm: {
         devDependencies: {

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,6 +1,7 @@
 /* eslint-env node */
 module.exports = {
   useYarn: true,
+  command: 'ember test --reporter xunit --skip-cleanup=true',
   scenarios: [
     {
       name: 'ember-2.10',

--- a/node-tests/blueprints/ember-power-select-test.js
+++ b/node-tests/blueprints/ember-power-select-test.js
@@ -22,8 +22,16 @@ function createStyleFixture(name) {
   fs.writeFileSync(path.join(stylePath, name), 'body { color: red; }');
 }
 
+function createSalsifyDir() {
+  let salsifyPath = path.join('node_modules', '@salsify');
+  if (!fs.existsSync(salsifyPath)) {
+    fs.mkdirSync(salsifyPath);
+  }
+}
+
 describe('Acceptance: ember generate ember-power-select', function() {
   setupTestHooks(this);
+  createSalsifyDir();
 
   it('skips blueprint when no preprocessor present', function() {
     let args = ['ember-power-select'];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "ember-power-select",
-  "version": "2.0.0-beta.0",
+  "name": "@salsify/ember-power-select",
+  "version": "2.0.0-beta.0-0.2.0",
   "description": "The extensible select component built for ember",
   "keywords": [
     "ember-addon",
@@ -19,15 +19,12 @@
     "doc": "doc",
     "test": "tests"
   },
-  "repository": {
-    "type": "git",
-    "url": "http://github.com/cibernox/ember-power-select.git"
-  },
+  "repository": "salsify/ember-power-select",
   "scripts": {
     "build": "ember build",
     "start": "ember serve",
     "test": "ember try:each",
-    "nodetest": "$(npm bin)/mocha node-tests --recursive"
+    "nodetest": "mocha node-tests --recursive"
   },
   "files": [
     "addon/",
@@ -82,7 +79,7 @@
     "testdouble": "^3.2.6"
   },
   "engines": {
-    "node": "^4.5 || 6.* || >= 7.*"
+    "node": ">= 4.0.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "testdouble": "^3.2.6"
   },
   "engines": {
-    "node": ">= 4.0.0"
+    "node": "^4.5 || 6.* || >= 7.*"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",

--- a/testem.js
+++ b/testem.js
@@ -2,6 +2,7 @@
 module.exports = {
   test_page: 'tests/index.html?hidepassed',
   disable_watching: true,
+  report_file: `./test-output/${process.env.EMBER_TRY_CURRENT_SCENARIO}/output.xml`,
   launch_in_ci: [
     'Chrome'
   ],

--- a/tests/dummy/app/templates/public-pages/docs/api-reference.hbs
+++ b/tests/dummy/app/templates/public-pages/docs/api-reference.hbs
@@ -188,6 +188,11 @@
       <td>The function to be invoked when component is opened</td>
     </tr>
     <tr>
+      <td>onscroll</td>
+      <td><code>function</code></td>
+      <td>The function to be invoked when the options component is scrolled</td>
+    </tr>
+    <tr>
       <td>options</td>
       <td><code>collection</code></td>
       <td>Collection of options to display in the component</td>

--- a/tests/integration/components/power-select/public-actions-test.js
+++ b/tests/integration/components/power-select/public-actions-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { clickTrigger, typeInSearch } from 'ember-power-select/test-support/helpers';
+import { clickTrigger, typeInSearch, triggerScroll } from 'ember-power-select/test-support/helpers';
 import { numbers } from '../constants';
 import { find, findAll, click, keyEvent, focus } from 'ember-native-dom-helpers';
 import { run } from '@ember/runloop';
@@ -569,6 +569,24 @@ module('Integration | Component | Ember Power Select (Public actions)', function
     assert.equal(find('.ember-power-select-option[aria-current="true"]').textContent.trim(), 'baz', 'The third option is highlighted');
   });
 
+  test('The `onscroll` action of single selects action receives the public API and the event', async function(assert) {
+    assert.expect(22);
+
+    this.numbers = numbers;
+    this.handleScroll = (select, e) => {
+      assertPublicAPIShape(assert, select);
+      assert.ok(e instanceof window.Event, 'The second argument is an event');
+    };
+
+    await render(hbs`
+      {{#power-select initiallyOpened=true options=numbers onscroll=handleScroll onchange=(action (mut foo)) as |number|}}
+        {{number}}
+      {{/power-select}}
+    `);
+
+    await triggerScroll(0, 20);
+  });
+
   test('The programmer can use the received public API to perform searches in single selects', async function(assert) {
     assert.expect(2);
 
@@ -692,4 +710,3 @@ module('Integration | Component | Ember Power Select (Public actions)', function
     run(() => this.selectAPI.actions.scrollTo('three'));
   });
 });
-


### PR DESCRIPTION
This PR works in tandem with #5 to get us up-to-date with `upstream/master`, applying all of the changes we've made since we forked `cibernox/ember-power-select`.

prime: @dfreeman 